### PR TITLE
Add Google Analytics tracking ID

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -35,6 +35,12 @@ const config = {
   presets: [
     [
       'classic',
+      {
+        gtag: {
+          trackingID: `G-W64Y138P08`,
+          anonymizeIP: true,
+        },
+      },
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {


### PR DESCRIPTION
- Follow this guide, https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag