### PR TITLE
Add manual triggered github action to deploy to production.

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,34 @@
+name: Deploy to Production
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Prepare
+      run: |
+        sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+        echo "${{secrets.WEIHAILU}}" > identity.pem
+        chmod 400 identity.pem
+        mkdir -p ~/.config/dfx/identity/default
+        mv identity.pem ~/.config/dfx/identity/default/identity.pem
+        dfx identity list
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+    - name: Build
+      run: |
+        cd docusaurus
+        npm install
+        yarn build
+        cd ..
+    - name: Deploy
+      run: |
+        rm canister_ids.json
+        echo '{ "ic123_frontend": { "ic": "${{ vars.PRODUCTION_CANISTER_ID }}" } }' > canister_ids.json
+        dfx start --background --clean
+        dfx deploy --network=ic


### PR DESCRIPTION
You can go to `Actions` to trigger this action manually once this pr is merged, it's similar to the below screenshot

![image](https://github.com/ic123-xyz/ic123/assets/5909911/4648e693-eb98-4934-a398-c0afedb6053f)

For now we only checkout to the default branch, which means selecting the branch from the UI won't work. We can support branches, tags, and revision hashes once we have the whole workflow set up.

The `deploy-production.yml` file is very similar to `deploy-staging.yml`, and actually they could be combined. The reason why I separate them is to reduce the chance that people deploy to the wrong target...

