### PR TITLE
Add build summary.

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,3 +32,5 @@ jobs:
         echo '{ "ic123_frontend": { "ic": "${{ vars.PRODUCTION_CANISTER_ID }}" } }' > canister_ids.json
         dfx start --background --clean
         dfx deploy --network=ic
+    - name: Summarize
+      run: echo 'https://${{ vars.PRODUCTION_CANISTER_ID }}.icp0.io' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -33,3 +33,5 @@ jobs:
         echo '{ "ic123_frontend": { "ic": "${{ vars.STAGING_CANISTER_ID }}" } }' > canister_ids.json
         dfx start --background --clean
         dfx deploy --network=ic
+    - name: Summarize
+      run: echo 'https://${{ vars.STAGING_CANISTER_ID }}.icp0.io' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Add the build summary, then people can easily navigate to the deployed canister to verify the result, like below

![image](https://github.com/ic123-xyz/ic123/assets/5909911/75988393-547e-4604-a0e2-25e145cd4d2b)
