### PR TITLE
Fetch all the history and tags to fix the last editor issue.

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Prepare
       run: |
         sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Prepare
       run: |
         sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"


### PR DESCRIPTION
By default `checkout` is only checking depth 1, switch to `fetch-depth: 0` to fetch all the history and tags (please refer to its document https://github.com/actions/checkout#usage for details.) as docusaurus needs the info to figure out the last editors for each pages.

Here is a result https://gzdkp-wyaaa-aaaan-qd5la-cai.icp0.io/docs/ic-web3/stake-icp that I deployed from my fork, the last editors look correct to me.

