### PR TITLE
Fix the deployment error.

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,7 @@ jobs:
         fetch-depth: 0
     - name: Prepare
       run: |
-        sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+        DFX_VERSION=0.14.3 sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
         echo "${{secrets.WEIHAILU}}" > identity.pem
         chmod 400 identity.pem
         mkdir -p ~/.config/dfx/identity/default

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
     - name: Prepare
       run: |
-        sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+        DFX_VERSION=0.14.3 sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
         echo "${{secrets.WEIHAILU}}" > identity.pem
         chmod 400 identity.pem
         mkdir -p ~/.config/dfx/identity/default


### PR DESCRIPTION
Fix the deployment error by setting the dfx version to 0.14.3 temporarily. The reason is the default version of dfx has been updated from 0.14.3 to 0.14.4, which needs a Wasm code upgrade. We need to add the identity we used as the controllers of the canisters afterwards.